### PR TITLE
Use curl instead of wget, detect the name of the main volume, cleanup

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 set -e
 
-info="\033[0;32m==> info ]\033[0m"
-warning="\033[0;33m==> warn ]\033[0m"
-error="\033[0;31m==> error ]\033[0m"
+info()  { echo -e "[\033[0;32m info  \033[0m] ${*}" ; }
+warn()  { echo -e "[\033[0;33m warn  \033[0m] ${*}" ; }
+error() { echo -e "[\033[0;31m error \033[0m] ${*}" ; }
+fatal() { error $* 1>&2 ; exit 1 ; }
 
 check_root() {
   if [[ $EUID -ne 0 ]]; then
-      echo -e "$error This script must be run as root\n$info You could also run: sudo $0" 1>&2
-      exit 1
+    fatal "This script must be run as root\n$info You could also run: sudo $0"
   fi
 }
 
@@ -16,71 +16,85 @@ detect_osx_version() {
   result=`sw_vers -productVersion`
 
   if [[ $result =~ "10.7" ]]; then
-      osxversion="10.7"
-      osxvername="Lion"
-      cltools=xcode46cltools_10_76938132a.dmg
-      mountpath="/Volumes/Command Line Tools (Lion)"
-      mpkg="Command Line Tools (Lion).mpkg"
-      pkg_url="https://www.dropbox.com/s/fnqgdilm0yddfc0/xcode462_cltools_10_76938260a.dmg"
-      pkgmd5="ca48a44bfbf61d0dce9692ba4edb204f"
-      #downloaded from: https://developer.apple.com/downloads/
+    osxversion="10.7"
+    osxvername="Lion"
+    cltools=xcode46cltools_10_76938132a.dmg
+    mountpath="/Volumes/Command Line Tools (Lion)"
+    mpkg="Command Line Tools (Lion).mpkg"
+    pkg_url="https://www.dropbox.com/s/fnqgdilm0yddfc0/xcode462_cltools_10_76938260a.dmg"
+    pkgmd5="ca48a44bfbf61d0dce9692ba4edb204f"
+    #downloaded from: https://developer.apple.com/downloads/
   elif [[ $result =~ "10.8" ]]; then
-      osxversion="10.8"
-      osxvername="Mountain Lion"
-      cltools=xcode462_cltools_10_86938259a.dmg
-      mountpath="/Volumes/Command Line Tools (Mountain Lion)"
-      mpkg="Command Line Tools (Mountain Lion).mpkg"
-      pkg_url="https://www.dropbox.com/s/hw45wvjxrkrl59x/xcode462_cltools_10_86938259a.dmg"
-      pkgmd5="90c5db99a589c269efa542ff0272fc28"
-      #downloaded from: https://developer.apple.com/downloads/
+    osxversion="10.8"
+    osxvername="Mountain Lion"
+    cltools=xcode462_cltools_10_86938259a.dmg
+    mountpath="/Volumes/Command Line Tools (Mountain Lion)"
+    mpkg="Command Line Tools (Mountain Lion).mpkg"
+    pkg_url="https://www.dropbox.com/s/hw45wvjxrkrl59x/xcode462_cltools_10_86938259a.dmg"
+    pkgmd5="90c5db99a589c269efa542ff0272fc28"
+    #downloaded from: https://developer.apple.com/downloads/
   else
-      echo -e "$error This machine is running an unsupported version of OS X" 1>&2
-      exit 1
+    fatal "This machine is running an unsupported version of OS X"
   fi
 
-  echo -e "$info Detected OS X $osxversion $osxvername"
+  info "Detected OS X $osxversion $osxvername"
 }
 
 check_tools() {
   RECEIPT_FILE=/var/db/receipts/com.apple.pkg.DeveloperToolsCLI.bom
-  if [ -f "$RECEIPT_FILE" ]; then 
-    echo -e "$info Command Line Tools are already installed. Exiting..." 
+  if [ -f "$RECEIPT_FILE" ]; then
+    info "Command Line Tools are already installed. Exiting..."
     exit 0
   fi
 }
 
-download_tools () {
-  # Use wget to download the appropriate installer curl has some issues (or I couldn't find the flags :)
+verify_download() {
   if [ -f /tmp/$cltools ]; then
-    # indirmd5=`md5 -q /tmp/$cltools`
     if [ `md5 -q /tmp/$cltools` = "${pkgmd5}" ]; then
-      echo -e "$info $cltools already downloaded to /tmp/$cltools."
+      info "$cltools checksum verified"
     else
-       rm -f /tmp/$cltools
+      warn "/tmp/$cltools checksum is invalid, retrying download"
+      rm -f /tmp/$cltools
+      download_tools
     fi
   else
-    cd /tmp && wget $pkg_url -O ./$cltools
+    download_tools
   fi
+}
+
+download_tools () {
+  info "Downloading $cltools"
+  curl -L -s $pkg_url > /tmp/$cltools
+  verify_download
+}
+
+main_volume_name() {
+  # The main volume is typically, but not necessarily called '/Volumes/Macintosh HD'
+  root_disk=$(df -l /|tail -1|cut -d' ' -f1)
+  volume_name=$(diskutil info $root_disk | grep 'Volume Name' | sed 's/.*Name: *//')
+  [[ -z "$volume_name" ]] && fatal "Failed to locate main HD volume"
+  [[ ! -d "/Volumes/$volume_name" ]] && fatal "Something went wrong, $volume_name is not a directory"
+  echo "/Volumes/$volume_name"
 }
 
 install_tools() {
   # Mount the Command Line Tools dmg
-  echo -e "$info Mounting Command Line Tools..."
+  info "Mounting Command Line Tools"
   hdiutil mount -nobrowse /tmp/$cltools
   # Run the Command Line Tools Installer
-  echo -e "$info Installing Command Line Tools..."
-  installer -pkg "$mountpath/$mpkg" -target "/Volumes/Macintosh HD"
+  info "Installing Command Line Tools"
+  installer -pkg "$mountpath/$mpkg" -target "$(main_volume_name)"
   # Unmount the Command Line Tools dmg
-  echo -e "$info Unmounting Command Line Tools..."
+  info "Unmounting Command Line Tools"
   hdiutil unmount "$mountpath"
 
   gcc_bin=`which gcc`
   gcc --version &>/dev/null && echo -e "$info gcc found in $gcc_bin"
 }
- 
+
 cleanup () {
   rm /tmp/$cltools
-  echo -e "$info Cleanup complete."
+  info "Cleanup complete."
   exit 0
 }
 
@@ -91,7 +105,7 @@ main() {
   # Check for if tools are already installed by looking for a receipt file
   check_tools
   # Check for and if necessary download the required dmg
-  download_tools
+  verify_download
   # Start the appropriate installer for the correct version of OSX
   install_tools
   # Cleanup files used during script


### PR DESCRIPTION
Wget isn't available on a vanilla install (at least not on the 10.8 I tried).

The script will now detect the name of the main volume, rather than assuming
it's always 'Macintosh HD'

I also wrapped the info/warn/error in nicer functions and made indentation
consistent across the script.
